### PR TITLE
Fix/renaming api name

### DIFF
--- a/addon/components/tawk-messenger.js
+++ b/addon/components/tawk-messenger.js
@@ -61,122 +61,122 @@ export default class TawkMessengerComponent extends Component {
 	 */
 	mapListeners() {
 		window.addEventListener('tawkLoad', () => {
-			if (this.args.onLoad) {
-				this.args.onLoad();
+			if (this.args.tawkOnLoad) {
+				this.args.tawkOnLoad();
 			}
 		});
 
 		window.addEventListener('tawkStatusChange', (status) => {
-			if (this.args.onStatusChange) {
-				this.args.onStatusChange(status.detail);
+			if (this.args.tawkOnStatusChange) {
+				this.args.tawkOnStatusChange(status.detail);
 			}
 		});
 
 		window.addEventListener('tawkBeforeLoad', () => {
-			if (this.args.onBeforeLoad) {
-				this.args.onBeforeLoad();
+			if (this.args.tawkOnBeforeLoad) {
+				this.args.tawkOnBeforeLoad();
 			}
 		});
 
 		window.addEventListener('tawkChatMaximized', () => {
-			if (this.args.onChatMaximized) {
-				this.args.onChatMaximized();
+			if (this.args.tawkOnChatMaximized) {
+				this.args.tawkOnChatMaximized();
 			}
 		});
 
 		window.addEventListener('tawkChatMinimized', () => {
-			if (this.args.onChatMinimized) {
-				this.args.onChatMinimized();
+			if (this.args.tawkOnChatMinimized) {
+				this.args.tawkOnChatMinimized();
 			}
 		});
 
 		window.addEventListener('tawkChatHidden', () => {
-			if (this.args.onChatHidden) {
-				this.args.onChatHidden();
+			if (this.args.tawkOnChatHidden) {
+				this.args.tawkOnChatHidden();
 			}
 		});
 
 		window.addEventListener('tawkChatStarted', () => {
-			if (this.args.onChatStarted) {
-				this.args.onChatStarted();
+			if (this.args.tawkOnChatStarted) {
+				this.args.tawkOnChatStarted();
 			}
 		});
 
 		window.addEventListener('tawkChatEnded', () => {
-			if (this.args.onChatEnded) {
-				this.args.onChatEnded();
+			if (this.args.tawkOnChatEnded) {
+				this.args.tawkOnChatEnded();
 			}
 		});
 
 		window.addEventListener('tawkPrechatSubmit', (data) => {
-			if (this.args.onPrechatSubmit) {
-				this.args.onPrechatSubmit(data.detail);
+			if (this.args.tawkOnPrechatSubmit) {
+				this.args.tawkOnPrechatSubmit(data.detail);
 			}
 		});
 
 		window.addEventListener('tawkOfflineSubmit', (data) => {
-			if (this.args.onOfflineSubmit) {
-				this.args.onOfflineSubmit(data.detail);
+			if (this.args.tawkOnOfflineSubmit) {
+				this.args.tawkOnOfflineSubmit(data.detail);
 			}
 		});
 
 		window.addEventListener('tawkChatMessageVisitor', (message) => {
-			if (this.args.onChatMessageVisitor) {
-				this.args.onChatMessageVisitor(message.detail);
+			if (this.args.tawkOnChatMessageVisitor) {
+				this.args.tawkOnChatMessageVisitor(message.detail);
 			}
 		});
 
 		window.addEventListener('tawkChatMessageAgent', (message) => {
-			if (this.args.onChatMessageAgent) {
-				this.args.onChatMessageAgent(message.detail);
+			if (this.args.tawkOnChatMessageAgent) {
+				this.args.tawkOnChatMessageAgent(message.detail);
 			}
 		});
 
 		window.addEventListener('tawkChatMessageSystem', (message) => {
-			if (this.args.onChatMessageSystem) {
-				this.args.onChatMessageSystem(message.detail);
+			if (this.args.tawkOnChatMessageSystem) {
+				this.args.tawkOnChatMessageSystem(message.detail);
 			}
 		});
 
 		window.addEventListener('tawkAgentJoinChat', (data) => {
-			if (this.args.onAgentJoinChat) {
-				this.args.onAgentJoinChat(data.detail);
+			if (this.args.tawkOnAgentJoinChat) {
+				this.args.tawkOnAgentJoinChat(data.detail);
 			}
 		});
 
 		window.addEventListener('tawkAgentLeaveChat', (data) => {
-			if (this.args.onAgentLeaveChat) {
-				this.args.onAgentLeaveChat(data.detail);
+			if (this.args.tawkOnAgentLeaveChat) {
+				this.args.tawkOnAgentLeaveChat(data.detail);
 			}
 		});
 
 		window.addEventListener('tawkChatSatisfaction', (satisfaction) => {
-			if (this.args.onChatSatisfaction) {
-				this.args.onChatSatisfaction(satisfaction.detail);
+			if (this.args.tawkOnChatSatisfaction) {
+				this.args.tawkOnChatSatisfaction(satisfaction.detail);
 			}
 		});
 
 		window.addEventListener('tawkVisitorNameChanged', (visitorName) => {
-			if (this.args.onVisitorNameChanged) {
-				this.args.onVisitorNameChanged(visitorName.detail);
+			if (this.args.tawkOnVisitorNameChanged) {
+				this.args.tawkOnVisitorNameChanged(visitorName.detail);
 			}
 		});
 
 		window.addEventListener('tawkFileUpload', (link) => {
-			if (this.args.onFileUpload) {
-				this.args.onFileUpload(link.detail);
+			if (this.args.tawkOnFileUpload) {
+				this.args.tawkOnFileUpload(link.detail);
 			}
 		});
 
 		window.addEventListener('tawkTagsUpdated', (data) => {
-			if (this.args.onTagsUpdated) {
-				this.args.onTagsUpdated(data.detail);
+			if (this.args.tawkOnTagsUpdated) {
+				this.args.tawkOnTagsUpdated(data.detail);
 			}
 		});
 
 		window.addEventListener('tawkUnreadCountChanged', (data) => {
-			if (this.args.onUnreadCountChanged) {
-				this.args.onUnreadCountChanged(data.detail);
+			if (this.args.tawkOnUnreadCountChanged) {
+				this.args.tawkOnUnreadCountChanged(data.detail);
 			}
 		});
 	}

--- a/addon/services/tawk-messenger.js
+++ b/addon/services/tawk-messenger.js
@@ -91,7 +91,7 @@ export default class TawkMessenger extends Service {
 	/**
 	 * API for setting a data on the widget
 	 */
-	tawkvisitor(data) {
+	tawkVisitor(data) {
 		window.Tawk_API.visitor = data;
 	}
 

--- a/addon/services/tawk-messenger.js
+++ b/addon/services/tawk-messenger.js
@@ -13,101 +13,101 @@ export default class TawkMessenger extends Service {
 	/**
 	 * API for calling an action on the widget
 	 */
-	maximize() {
+	tawkMaximize() {
 		return window.Tawk_API.maximize();
 	}
 
-	minimize() {
+	tawkMinimize() {
 		return window.Tawk_API.minimize();
 	}
 
-	toggle() {
+	tawkToggle() {
 		return window.Tawk_API.toggle();
 	}
 
-	popup() {
+	tawkPopup() {
 		return window.Tawk_API.popup();
 	}
 
-	showWidget() {
+	tawkShowWidget() {
 		return window.Tawk_API.showWidget();
 	}
 
-	hideWidget() {
+	tawkHideWidget() {
 		return window.Tawk_API.hideWidget();
 	}
 
-	toggleVisibility() {
+	tawkToggleVisibility() {
 		return window.Tawk_API.toggleVisibility();
 	}
 
-	endChat() {
+	tawkEndChat() {
 		return window.Tawk_API.endChat();
 	}
 
 	/**
 	 * API for returning a data
 	 */
-	getWindowType() {
+	tawkGetWindowType() {
 		return window.Tawk_API.getWindowType();
 	}
 
-	getStatus() {
+	tawkGetStatus() {
 		return window.Tawk_API.getStatus();
 	}
 
-	isChatMaximized() {
+	tawkIsChatMaximized() {
 		return window.Tawk_API.isChatMaximized();
 	}
 
-	isChatMinimized() {
+	tawkIsChatMinimized() {
 		return window.Tawk_API.isChatMinimized();
 	}
 
-	isChatHidden() {
+	tawkIsChatHidden() {
 		return window.Tawk_API.isChatHidden();
 	}
 
-	isChatOngoing() {
+	tawkIsChatOngoing() {
 		return window.Tawk_API.isChatOngoing();
 	}
 
-	isVisitorEngaged() {
+	tawkIsVisitorEngaged() {
 		return window.Tawk_API.isVisitorEngaged();
 	}
 
-	onLoaded() {
+	tawkOnLoaded() {
 		return window.Tawk_API.onLoaded;
 	}
 
-	onBeforeLoaded() {
+	tawkOnBeforeLoaded() {
 		return window.Tawk_API.onBeforeLoaded;
 	}
 
-	widgetPosition() {
+	tawkWidgetPosition() {
 		return window.Tawk_API.widgetPosition();
 	}
 
 	/**
 	 * API for setting a data on the widget
 	 */
-	visitor(data) {
+	tawkvisitor(data) {
 		window.Tawk_API.visitor = data;
 	}
 
-	setAttributes(attribute, callback) {
+	tawkSetAttributes(attribute, callback) {
 		window.Tawk_API.setAttributes(attribute, callback);
 	}
 
-	addEvent(event, metadata, callback) {
+	tawkAddEvent(event, metadata, callback) {
 		window.Tawk_API.addEvent(event, metadata, callback);
 	}
 
-	addTags(tags, callback) {
+	tawkAddTags(tags, callback) {
 		window.Tawk_API.addTags(tags, callback);
 	}
 
-	removeTags(tags, callback) {
+	tawkRemoveTags(tags, callback) {
 		window.Tawk_API.removeTags(tags, callback);
 	}
 }

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -10,49 +10,49 @@ Use the JavaScript API to manipulate the chat widget displayed on your website.
 ## Table of contents
 - [API Reference](#api-reference)
   - [Table of contents](#table-of-contents)
-  - [onLoad](#onload)
-  - [onStatusChange](#onstatuschange)
-  - [onBeforeLoad](#onbeforeload)
-  - [onChatMaximized](#onchatmaximized)
-  - [onChatMinimized](#onchatminimized)
-  - [onChatHidden](#onchathidden)
-  - [onChatStarted](#onchatstarted)
-  - [onChatEnded](#onchatended)
-  - [onPrechatSubmit](#onprechatsubmit)
-  - [onOfflineSubmit](#onofflinesubmit)
-  - [onChatMessageVisitor](#onchatmessagevisitor)
-  - [onChatMessageAgent](#onchatmessageagent)
-  - [onChatMessageSystem](#onchatmessagesystem)
-  - [onAgentJoinChat](#onagentjoinchat)
-  - [onAgentLeaveChat](#onagentleavechat)
-  - [onChatSatisfaction](#onchatsatisfaction)
-  - [onVisitorNameChanged](#onvisitornamechanged)
-  - [onFileUpload](#onfileupload)
-  - [onTagsUpdated](#ontagsupdated)
-  - [onUnreadCountChanged](#onunreadcountchanged)
-  - [visitor](#visitor)
-  - [maximize](#maximize)
-  - [minimize](#minimize)
-  - [toggle](#toggle)
-  - [popup](#popup)
-  - [getWindowType](#getwindowtype)
-  - [showWidget](#showwidget)
-  - [hideWidget](#hidewidget)
-  - [toggleVisibility](#togglevisibility)
-  - [getStatus](#getstatus)
-  - [isChatMaximized](#ischatmaximized)
-  - [isChatMinimized](#ischatminimized)
-  - [isChatHidden](#ischathidden)
-  - [isChatOngoing](#ischatongoing)
-  - [isVisitorEngaged](#isvisitorengaged)
-  - [onLoaded](#onloaded)
-  - [onBeforeLoaded](#onbeforeloaded)
-  - [widgetPosition](#widgetposition)
-  - [endChat](#endchat)
-  - [setAttributes](#setattributes)
-  - [addEvent](#addevent)
-  - [addTags](#addtags)
-  - [removeTags](#removetags)
+  - [tawkOnLoad](#tawkonload)
+  - [tawkOnStatusChange](#tawkonstatuschange)
+  - [tawkOnBeforeLoad](#tawkonbeforeload)
+  - [tawkOnChatMaximized](#tawkonchatmaximized)
+  - [tawkOnChatMinimized](#tawkonchatminimized)
+  - [tawkOnChatHidden](#tawkonchathidden)
+  - [tawkOnChatStarted](#tawkonchatstarted)
+  - [tawkOnChatEnded](#tawkonchatended)
+  - [tawkOnPrechatSubmit](#tawkonprechatsubmit)
+  - [tawkOnOfflineSubmit](#tawkonofflinesubmit)
+  - [tawkOnChatMessageVisitor](#tawkonchatmessagevisitor)
+  - [tawkOnChatMessageAgent](#tawkonchatmessageagent)
+  - [tawkOnChatMessageSystem](#tawkonchatmessagesystem)
+  - [tawkOnAgentJoinChat](#tawkonagentjoinchat)
+  - [tawkOnAgentLeaveChat](#tawkonagentleavechat)
+  - [tawkOnChatSatisfaction](#tawkonchatsatisfaction)
+  - [tawkOnVisitorNameChanged](#tawkonvisitornamechanged)
+  - [tawkOnFileUpload](#tawkonfileupload)
+  - [tawkOnTagsUpdated](#tawkontagsupdated)
+  - [tawkOnUnreadCountChanged](#tawkonunreadcountchanged)
+  - [tawkVisitor](#tawkvisitor)
+  - [tawkMaximize](#tawkmaximize)
+  - [tawkMinimize](#tawkminimize)
+  - [tawkToggle](#tawktoggle)
+  - [tawkPopup](#tawkpopup)
+  - [tawkGetWindowType](#tawkgetwindowtype)
+  - [tawkShowWidget](#tawkshowwidget)
+  - [tawkHideWidget](#tawkhidewidget)
+  - [tawkToggleVisibility](#tawktogglevisibility)
+  - [tawkGetStatus](#tawkgetstatus)
+  - [tawkIsChatMaximized](#tawkischatmaximized)
+  - [tawkIsChatMinimized](#tawkischatminimized)
+  - [tawkIsChatHidden](#tawkischathidden)
+  - [tawkIsChatOngoing](#tawkischatongoing)
+  - [tawkIsVisitorEngaged](#tawkisvisitorengaged)
+  - [tawkOnLoaded](#tawkonloaded)
+  - [tawkOnBeforeLoaded](#tawkonbeforeloaded)
+  - [tawkWidgetPosition](#tawkwidgetposition)
+  - [tawkEndChat](#tawkendchat)
+  - [tawkSetAttributes](#tawksetattributes)
+  - [tawkAddEvent](#tawkaddevent)
+  - [tawkAddTags](#tawkaddtags)
+  - [tawkRemoveTags](#tawkremovetags)
   - [secureMode](#securemode)
   - [customstyle](#customstyle)
     - [zIndex](#zindex)
@@ -60,13 +60,13 @@ Use the JavaScript API to manipulate the chat widget displayed on your website.
 
 <br/>
 
-## onLoad
+## tawkOnLoad
 Callback function invoked right after the widget is rendered. This callback is not supported in pop out chat window.
 
 ``app/components/my-component.hbs``
 ```hbs
 <TawkMessenger
-    @onLoad={{this.handleOnLoad}}/>
+    @tawkOnLoad={{this.handleOnLoad}}/>
 ```
 
 ``app/components/my-component.js``
@@ -79,13 +79,13 @@ handleOnLoad() {
 
 <br/>
 
-## onStatusChange
+## tawkOnStatusChange
 Callback function invoked when the page status changes. The function will receive the changed status which will be either online, away or offline. This callback is not supported in pop out chat window.
 
 ``app/components/my-component.hbs``
 ```hbs
 <TawkMessenger
-    @onStatusChange={{this.handleOnStatusChange}}/>
+    @tawkOnStatusChange={{this.handleOnStatusChange}}/>
 ```
 
 ``app/components/my-component.js``
@@ -98,13 +98,13 @@ handleOnStatusChange(status) {
 
 <br/>
 
-## onBeforeLoad
+## tawkOnBeforeLoad
 Callback function invoked right when Tawk_API is ready to be used and before the widget is rendered. This callback is not supported in pop out chat window.
 
 ``app/components/my-component.hbs``
 ```hbs
 <TawkMessenger
-    @onBeforeLoad={{this.handleOnBeforeLoad}}/>
+    @tawkOnBeforeLoad={{this.handleOnBeforeLoad}}/>
 ```
 
 ``app/components/my-component.js``
@@ -117,13 +117,13 @@ handleOnBeforeLoad() {
 
 <br/>
 
-## onChatMaximized
+## tawkOnChatMaximized
 Callback function invoked when the widget is maximized. This callback is not supported in pop out chat window.
 
 ``app/components/my-component.hbs``
 ```hbs
 <TawkMessenger
-    @onChatMaximized={{this.handleOnChatMaximized}}/>
+    @tawkOnChatMaximized={{this.handleOnChatMaximized}}/>
 ```
 
 ``app/components/my-component.js``
@@ -136,32 +136,32 @@ handleOnChatMaximized() {
 
 <br/>
 
-## onChatMinimized
+## tawkOnChatMinimized
 Callback function invoked when the widget is minimized. This callback is not supported in pop out chat window.
 
 ``app/components/my-component.hbs``
 ```hbs
 <TawkMessenger
-    @onChatMaximized={{this.handleOnChatMaximized}}/>
+    @tawkOnChatMinimized={{this.handleOnChatMinimized}}/>
 ```
 
 ``app/components/my-component.js``
 ```js
 @action
-handleOnChatMaximized() {
+handleOnChatMinimized() {
     // place your code here
 }
 ```
 
 <br/>
 
-## onChatHidden
+## tawkOnChatHidden
 Callback function invoked when the widget is hidden. This callback is not supported in pop out chat window.
 
 ``app/components/my-component.hbs``
 ```hbs
 <TawkMessenger
-    @onChatHidden={{this.handleOnChatHidden}}/>
+    @tawkOnChatHidden={{this.handleOnChatHidden}}/>
 ```
 
 ``app/components/my-component.js``
@@ -174,13 +174,13 @@ handleOnChatHidden() {
 
 <br/>
 
-## onChatStarted
+## tawkOnChatStarted
 Callback function invoked when the widget is started.
 
 ``app/components/my-component.hbs``
 ```hbs
 <TawkMessenger
-    @onChatStarted={{this.handleOnChatStarted}}/>
+    @tawkOnChatStarted={{this.handleOnChatStarted}}/>
 ```
 
 ``app/components/my-component.js``
@@ -193,13 +193,13 @@ handleOnChatStarted() {
 
 <br/>
 
-## onChatEnded
+## tawkOnChatEnded
 Callback function invoked when the widget is ended. This callback is not supported in pop out chat window.
 
 ``app/components/my-component.hbs``
 ```hbs
 <TawkMessenger
-    @onChatEnded={{this.handleOnChatEnded}}/>
+    @tawkOnChatEnded={{this.handleOnChatEnded}}/>
 ```
 
 ``app/components/my-component.js``
@@ -212,13 +212,13 @@ handleOnChatEnded() {
 
 <br/>
 
-## onPrechatSubmit
+## tawkOnPrechatSubmit
 Callback function invoked when the Pre-Chat Form is submitted. The submitted form data is passed to the function. This callback is not supported in pop out chat window.
 
 ``app/components/my-component.hbs``
 ```hbs
 <TawkMessenger
-    @onPrechatSubmit={{this.handleOnPrechatSubmit}}/>
+    @tawkOnPrechatSubmit={{this.handleOnPrechatSubmit}}/>
 ```
 
 ``app/components/my-component.js``
@@ -231,13 +231,13 @@ handleOnPrechatSubmit(data) {
 
 <br/>
 
-## onOfflineSubmit
+## tawkOnOfflineSubmit
 Callback function invoked when the Offline form is submitted. The submitted form data is passed to the function. Form data will contain {name : ”, email : ”, message : ”, questions : []}. This callback is not supported in pop out chat window.
 
 ``app/components/my-component.hbs``
 ```hbs
 <TawkMessenger
-    @onOfflineSubmit={{this.handleOnOfflineSubmit}}/>
+    @tawkOnOfflineSubmit={{this.handleOnOfflineSubmit}}/>
 ```
 
 ``app/components/my-component.js``
@@ -250,13 +250,13 @@ handleOnOfflineSubmit(data) {
 
 <br/>
 
-## onChatMessageVisitor
+## tawkOnChatMessageVisitor
 Callback function invoked when message is sent by the visitor. The message is passed to the function. This callback is not supported in pop out chat window.
 
 ``app/components/my-component.hbs``
 ```hbs
 <TawkMessenger
-    @onChatMessageVisitor={{this.handleOnChatMessageVisitor}}/>
+    @tawkOnChatMessageVisitor={{this.handleOnChatMessageVisitor}}/>
 ```
 
 ``app/components/my-component.js``
@@ -269,13 +269,13 @@ handleOnChatMessageVisitor(message) {
 
 <br/>
 
-## onChatMessageAgent
+## tawkOnChatMessageAgent
 Callback function invoked when message is sent by the agent. The message is passed to the function. This callback is not supported in pop out chat window.
 
 ``app/components/my-component.hbs``
 ```hbs
 <TawkMessenger
-    @onChatMessageAgent={{this.handleOnChatMessageAgent}}/>
+    @tawkOnChatMessageAgent={{this.handleOnChatMessageAgent}}/>
 ```
 
 ``app/components/my-component.js``
@@ -288,13 +288,13 @@ handleOnChatMessageAgent(message) {
 
 <br/>
 
-## onChatMessageSystem
+## tawkOnChatMessageSystem
 Callback function invoked when message is sent by the system. The message is passed to the function. This callback is not supported in pop out chat window.
 
 ``app/components/my-component.hbs``
 ```hbs
 <TawkMessenger
-    @onChatMessageSystem={{this.handleOnChatMessageSystem}}/>
+    @tawkOnChatMessageSystem={{this.handleOnChatMessageSystem}}/>
 ```
 
 ``app/components/my-component.js``
@@ -307,13 +307,13 @@ handleOnChatMessageSystem(message) {
 
 <br/>
 
-## onAgentJoinChat
+## tawkOnAgentJoinChat
 Callback function invoked when an agent joins the chat. The data is passed to the function. Will contain {name : ”, position : ”, image : ”, id : ”}. This callback is not supported in pop out chat window.
 
 ``app/components/my-component.hbs``
 ```hbs
 <TawkMessenger
-    @onAgentJoinChat={{this.handleOnAgentJoinChat}}/>
+    @tawkOnAgentJoinChat={{this.handleOnAgentJoinChat}}/>
 ```
 
 ``app/components/my-component.js``
@@ -326,13 +326,13 @@ handleOnAgentJoinChat(data) {
 
 <br/>
 
-## onAgentLeaveChat
+## tawkOnAgentLeaveChat
 Callback function invoked when an agent leaves the chat. The data is passed to the function. Will contain {name : ”, id : ”}. This callback is not supported in pop out chat window.
 
 ``app/components/my-component.hbs``
 ```hbs
 <TawkMessenger
-    @onAgentLeaveChat={{this.handleOnAgentLeaveChat}}/>
+    @tawkOnAgentLeaveChat={{this.handleOnAgentLeaveChat}}/>
 ```
 
 ``app/components/my-component.js``
@@ -345,13 +345,13 @@ handleOnAgentLeaveChat(data) {
 
 <br/>
 
-## onChatSatisfaction
+## tawkOnChatSatisfaction
 Callback function invoked when an agent leaves the chat. The satisfaction is passed to the function. -1 = dislike | 0 = neutral | 1 = like. This callback is not supported in pop out chat window.
 
 ``app/components/my-component.hbs``
 ```hbs
 <TawkMessenger
-    @onChatSatisfaction={{this.handleOnChatSatisfaction}}/>
+    @tawkOnChatSatisfaction={{this.handleOnChatSatisfaction}}/>
 ```
 
 ``app/components/my-component.js``
@@ -364,13 +364,13 @@ handleOnChatSatisfaction(satisfaction) {
 
 <br/>
 
-## onVisitorNameChanged
+## tawkOnVisitorNameChanged
 Callback function invoked when the visitor manually changes his name. The visitorName is passed to the function. This callback is not supported in pop out chat window.
 
 ``app/components/my-component.hbs``
 ```hbs
 <TawkMessenger
-    @onVisitorNameChanged={{this.handleOnVisitorNameChanged}}/>
+    @tawkOnVisitorNameChanged={{this.handleOnVisitorNameChanged}}/>
 ```
 
 ``app/components/my-component.js``
@@ -383,13 +383,13 @@ handleOnVisitorNameChanged(visitorName) {
 
 <br/>
 
-## onFileUpload
+## tawkOnFileUpload
 Callback function invoked when a file is uploaded. The link to the uploaded file is passed to the function. This callback is not supported in pop out chat window.
 
 ``app/components/my-component.hbs``
 ```hbs
 <TawkMessenger
-    @onFileUpload={{this.handleOnFileUpload}}/>
+    @tawkOnFileUpload={{this.handleOnFileUpload}}/>
 ```
 
 ``app/components/my-component.js``
@@ -402,13 +402,13 @@ handleOnFileUpload(link) {
 
 <br/>
 
-## onTagsUpdated
+## tawkOnTagsUpdated
 Callback function invoked when a tag is updated.
 
 ``app/components/my-component.hbs``
 ```hbs
 <TawkMessenger
-    @onTagsUpdated={{this.handleOnTagsUpdated}}/>
+    @tawkOnTagsUpdated={{this.handleOnTagsUpdated}}/>
 ```
 
 ``app/components/my-component.js``
@@ -421,13 +421,13 @@ handleOnTagsUpdated(data) {
 
 <br/>
 
-## onUnreadCountChanged
+## tawkOnUnreadCountChanged
 Callback function returns count of unread messages.
 
 ``app/components/my-component.hbs``
 ```hbs
 <TawkMessenger
-    @onUnreadCountChanged={{this.handleOnUnreadCountChanged}}/>
+    @tawkOnUnreadCountChanged={{this.handleOnUnreadCountChanged}}/>
 ```
 
 ``app/components/my-component.js``
@@ -440,7 +440,7 @@ handleOnUnreadCountChanged(count) {
 
 <br/>
 
-## visitor
+## tawkVisitor
 Object used to set the visitor name and email. Do not place this object in a function, as the values need to be available before the widget script is downloaded.
 
 Setting or changing the values after the widget script has been downloaded will not send the values to the dashboard.
@@ -448,7 +448,7 @@ Setting or changing the values after the widget script has been downloaded will 
 If the name and email will not be available on load time (eg single page app, ajax login), then use the [setAttributes](#setAttributes) function instead.
 
 ```js
-this.tawkMessenger.visitor({
+this.tawkMessenger.tawkVisitor({
     name : 'Name',
     email : 'email@email.com'
 });
@@ -457,81 +457,81 @@ this.tawkMessenger.visitor({
 
 <br/>
 
-## maximize
+## tawkMaximize
 Maximizes the chat widget.
 
 ```js
-this.tawkMessenger.maximize();
+this.tawkMessenger.tawkMaximize();
 
 // Example
 
 @action
 handleOnLoad() {
-  this.tawkMessenger.maximize();
+  this.tawkMessenger.tawkMaximize();
 }
 ```
 
 <br/>
 
-## minimize
+## tawkMinimize
 Minimizes the chat widget.
 
 ```js
-this.tawkMessenger.minimize();
+this.tawkMessenger.tawkMinimize();
 
 // Example
 
 @action
 handleOnLoad() {
-    this.tawkMessenger.minimize();
+    this.tawkMessenger.tawkMinimize();
 }
 ```
 
 <br/>
 
-## toggle
+## tawkToggle
 Minimizes or Maximizes the chat widget based on the current state.
 
 ```js
-this.tawkMessenger.toggle();
+this.tawkMessenger.tawkToggle();
 
 // Example
 
 @action
 handleOnLoad() {
-    this.tawkMessenger.toggle();
+    this.tawkMessenger.tawkToggle();
 }
 ```
 
 <br/>
 
-## popup
+## tawkPopup
 Opens the chat widget as a pop out.
 
 ```js
-this.tawkMessenger.popup();
+this.tawkMessenger.tawkPopup();
 
 // Example
 
 @action
 handleOnLoad() {
-    this.tawkMessenger.popup();
+    this.tawkMessenger.tawkPopup();
 }
 ```
 
 <br/>
 
-## getWindowType
+## tawkGetWindowType
 Returns the current widget type whether it’s inline or embed.
 
 ```js
-this.tawkMessenger.getWindowType();
+this.tawkMessenger.tawkGetWindowType();
 
 // Example
 
 @action
 handleOnLoad() {
-    if (this.tawkMessenger.getWindowType() === 'inline') {
+    if (this.tawkMessenger.tawkGetWindowType() === 'inline') {
         // do something if it's inline
     } else {
         // do something if it's embed
@@ -541,65 +541,65 @@ handleOnLoad() {
 
 <br/>
 
-## showWidget
+## tawkShowWidget
 Shows the chat widget.
 
 ```js
-this.tawkMessenger.showWidget();
+this.tawkMessenger.tawkShowWidget();
 
 // Example
 
 @action
 handleOnLoad() {
-    this.tawkMessenger.showWidget();
+    this.tawkMessenger.tawkShowWidget();
 }
 ```
 
 <br/>
 
-## hideWidget
+## tawkHideWidget
 Hides the chat widget.
 
 ```js
-this.tawkMessenger.hideWidget();
+this.tawkMessenger.tawkHideWidget();
 
 // Example
 
 @action
 handleOnLoad() {
-    this.tawkMessenger.hideWidget();
+    this.tawkMessenger.tawkHideWidget();
 }
 ```
 
 <br/>
 
-## toggleVisibility
+## tawkToggleVisibility
 Hides or Shows the widget based on the current visibility state.
 
 ```js
-this.tawkMessenger.toggleVisibility();
+this.tawkMessenger.tawkToggleVisibility();
 
 // Example
 
 @action
 handleOnLoad() {
-    this.tawkMessenger.toggleVisibility();
+    this.tawkMessenger.tawkToggleVisibility();
 }
 ```
 
 <br/>
 
-## getStatus
+## tawkGetStatus
 Returns the current page status (online, away or offline).
 
 ```js
-this.tawkMessenger.getStatus();
+this.tawkMessenger.tawkGetStatus();
 
 // Example
 
 @action
 handleOnLoad() {
-    const pageStatus = this.tawkMessenger.getStatus();
+    const pageStatus = this.tawkMessenger.tawkGetStatus();
 
     if (pageStatus === 'online') {
         // do something for online
@@ -613,17 +613,17 @@ handleOnLoad() {
 
 <br/>
 
-## isChatMaximized
+## tawkIsChatMaximized
 Returns a boolean value (true or false) indicating whether the chat widget is maximized.
 
 ```js
-this.tawkMessenger.isChatMaximized();
+this.tawkMessenger.tawkIsChatMaximized();
 
 // Example
 
 @action
 handleOnLoad() {
-    if (this.tawkMessenger.isChatMaximized()) {
+    if (this.tawkMessenger.tawkIsChatMaximized()) {
         // do something it it's maximized
     }
 }
@@ -631,17 +631,17 @@ handleOnLoad() {
 
 <br/>
 
-## isChatMinimized
+## tawkIsChatMinimized
 Returns a boolean value (true or false) indicating whether the chat widget is minimized.
 
 ```js
-this.tawkMessenger.isChatMinimized();
+this.tawkMessenger.tawkIsChatMinimized();
 
 // Example
 
 @action
 handleOnLoad() {
-    if (this.tawkMessenger.isChatMinimized()) {
+    if (this.tawkMessenger.tawkIsChatMinimized()) {
         // do something if it's minimized
     }
 }
@@ -649,17 +649,17 @@ handleOnLoad() {
 
 <br/>
 
-## isChatHidden
+## tawkIsChatHidden
 Returns a boolean value (true or false) indicating whether the chat widget is hidden.
 
 ```js
-this.tawkMessenger.isChatHidden();
+this.tawkMessenger.tawkIsChatHidden();
 
 // Example
 
 @action
 handleOnLoad() {
-    if (this.tawkMessenger.isChatHidden()) {
+    if (this.tawkMessenger.tawkIsChatHidden()) {
         // do something if chat widget is hidden
     }
 }
@@ -667,17 +667,17 @@ handleOnLoad() {
 
 <br/>
 
-## isChatOngoing
+## tawkIsChatOngoing
 Returns a boolean value (true or false) indicating whether currently there is an ongoing chat.
 
 ```js
-this.tawkMessenger.isChatOngoing();
+this.tawkMessenger.tawkIsChatOngoing();
 
 // Example
 
 @action
 handleOnLoad() {
-    if (this.tawkMessenger.isChatOngoing()) {
+    if (this.tawkMessenger.tawkIsChatOngoing()) {
         // do something if there's ongoing chat
     }
 }
@@ -685,17 +685,17 @@ handleOnLoad() {
 
 <br/>
 
-## isVisitorEngaged
+## tawkIsVisitorEngaged
 Returns a boolean value (true or false) indicating whether the visitor is currently chatting or has requested a chat.
 
 ```js
-this.tawkMessenger.isVisitorEngaged();
+this.tawkMessenger.tawkIsVisitorEngaged();
 
 // Example
 
 @action
 handleOnLoad() {
-    if (this.tawkMessenger.isVisitorEngaged()) {
+    if (this.tawkMessenger.tawkIsVisitorEngaged()) {
         // do something if visitor engaged in chat
     }
 }
@@ -703,43 +703,43 @@ handleOnLoad() {
 
 <br/>
 
-## onLoaded
+## tawkOnLoaded
 Returns a boolean value (true or undefined) indicating when the plugin is ready.
 
 ```js
-this.tawkMessenger.onLoaded();
+this.tawkMessenger.tawkOnLoaded();
 
 // Example
 
-if (this.tawkMessenger.onLoaded()) {
+if (this.tawkMessenger.tawkOnLoaded()) {
     // do something when widget is ready
 }
 ```
 
-## onBeforeLoaded
+## tawkOnBeforeLoaded
 Returns a boolean value (true or undefined) indicating when plugin is initialized.
 
 ```js
-this.tawkMessenger.onBeforeLoaded();
+this.tawkMessenger.tawkOnBeforeLoaded();
 
 // Example
 
-if (this.tawkMessenger.onBeforeLoaded()) {
+if (this.tawkMessenger.tawkOnBeforeLoaded()) {
     // do something before onload
 }
 ```
 
-## widgetPosition
+## tawkWidgetPosition
 Returns a string for current position of the widget.
 
 ```js
-this.tawkMessenger.widgetPosition();
+this.tawkMessenger.tawkWidgetPosition();
 
 // Example
 
 @action
 handleOnLoad() {
-    if (this.tawkMessenger.widgetPosition() === 'br') {
+    if (this.tawkMessenger.tawkWidgetPosition() === 'br') {
         // do something if the widget is at bottom right
     }
 }
@@ -747,23 +747,23 @@ handleOnLoad() {
 
 <br/>
 
-## endChat
+## tawkEndChat
 Ends the current ongoing chat.
 
 ```js
-this.tawkMessenger.endChat();
+this.tawkMessenger.tawkEndChat();
 
 // Example
 
 @action
 handleOnLoad() {
-    this.tawkMessenger.endChat();
+    this.tawkMessenger.tawkEndChat();
 }
 ```
 
 <br/>
 
-## setAttributes
+## tawkSetAttributes
 Sets custom metadata regarding this chat/visitor.
 
 This function takes in two values: attribute and callback.
@@ -791,13 +791,13 @@ Error messages returned:
 1. CONTAINS_INVALID_VALUE: Custom value is empty or the total length is more than 255 characters
 
 ```js
-this.tawkMessenger.setAttributes(attributes, callback);
+this.tawkMessenger.tawkSetAttributes(attributes, callback);
 
 // Example
 
 @action
 handleOnLoad() {
-    this.tawkMessenger.setAttributes({
+    this.tawkMessenger.tawkSetAttributes({
         id : 'A1234',
         store : 'Midvalley'
     }, function(error) {
@@ -809,7 +809,7 @@ handleOnLoad() {
 
 @action
 handleOnLoad() {
-    this.tawkMessenger.setAttributes({
+    this.tawkMessenger.tawkSetAttributes({
         name : 'Name',
         email : 'email@email.com',
         hash : 'hash value'
@@ -821,7 +821,7 @@ handleOnLoad() {
 
 <br/>
 
-## addEvent
+## tawkAddEvent
 Sets a custom event to chat.
 This function takes in 3 values: event name, optional metadata and callback.
 
@@ -832,20 +832,20 @@ The callback which is a function will be invoked to notify whether the save fail
 INVALID_EVENT_NAME, INVALID_ATTRIBUTES, ATTRIBUTE_LIMIT_EXCEEDED, CONTAINS_INVALID_KEY, CONTAINS_INVALID_VALUE, SESSION_EXPIRED, SERVER_ERROR
 
 ```js
-this.tawkMessenger.addEvent(eventName, metaData, callback);
+this.tawkMessenger.tawkAddEvent(eventName, metaData, callback);
 
 // Example
 
 @action
 handleOnLoad() {
-    this.tawkMessenger.addEvent(
+    this.tawkMessenger.tawkAddEvent(
         'requested-quotation',
         function(error) {
             // do something if error
         }
     );
 
-    this.tawkMessenger.addEvent(
+    this.tawkMessenger.tawkAddEvent(
         'product-add-to-cart',
         {
             sku : 'A0012',
@@ -861,7 +861,7 @@ handleOnLoad() {
 
 <br/>
 
-## addTags
+## tawkAddTags
 Adds tags to the chat.
 This function takes in two values: tags and callback.
 This is of the array data type.
@@ -873,13 +873,13 @@ The callback, which is a function, will be invoked to notify whether the save fa
 INVALID_TAGS, TAG_LIMIT_EXCEEDED, VERSION_CONFLICT, SESSION_EXPIRED, SERVER_ERROR
 
 ```js
-this.tawkMessenger.addTags(tags, callback);
+this.tawkMessenger.tawkAddTags(tags, callback);
 
 // Example
 
 @action
 handleOnLoad() {
-    this.tawkMessenger.addTags(
+    this.tawkMessenger.tawkAddTags(
         [
             'hello',
             'world'
@@ -893,7 +893,7 @@ handleOnLoad() {
 
 <br/>
 
-## removeTags
+## tawkRemoveTags
 Removes tags from the chat.
 This function takes in two values: tags and callback.
 This is of the array data type.
@@ -904,13 +904,13 @@ The callback, which is a function, will be invoked to notify whether the save fa
 INVALID_TAGS, TAG_LIMIT_EXCEEDED, SESSION_EXPIRED, SERVER_ERROR
 
 ```js
-this.tawkMessenger.removeTags(tags, callback);
+this.tawkMessenger.tawkRemoveTags(tags, callback);
 
 // Example
 
 @action
 handleOnLoad() {
-  this.tawkMessenger.removeTags(
+  this.tawkMessenger.tawkRemoveTags(
     [
       'hello',
       'world'
@@ -934,7 +934,7 @@ The hash is server side generated HMAC using SHA256, the user’s email and your
 You can get your API key from **Admin>Property Settings**.
 
 ```js
-this.tawkMessenger.visitor({
+this.tawkMessenger.tawkVisitor({
   name : 'Name',
   email : 'email@email.com',
   hash : '<calculate-hash>'


### PR DESCRIPTION
## Summary
There are users reported collision of provider keys since we use generic naming on our API. I added prefix tawk in all actions, getters, listeners, and setters. 

> This will lead to breaking changes since all APIs will be renamed, need to include in the changelog and update our application also

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced naming convention for event handlers and methods in the Tawk Messenger component and service for improved clarity.
  
- **Documentation**
	- Updated API documentation to reflect new method names, ensuring consistency and clarity for users. Example code snippets have also been revised to align with the new naming conventions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->